### PR TITLE
fix(model/Challenge): Add -1 for currentProblem enum

### DIFF
--- a/models/Challenge.js
+++ b/models/Challenge.js
@@ -48,7 +48,7 @@ const ChallengeSchema = new Schema({
   currentProblem: {
     type: Number,
     required: true,
-    enum: [0, 1, 2, 3, 4, 5],
+    enum: [-1, 0, 1, 2, 3, 4, 5],
     default: 0,
   },
   subtopicName: {


### PR DESCRIPTION
ตอนแรก เวลา user1 ทำข้อสุดท้ายถูกแต่มันไปอัพเดทว่าผิด เพราะ currentProblem เป็น -1 ซึ่งไม่มีใน enum ที่อยู่ใน ChallengeSchema เราเลยไปเพิ่ม enum 
สาเหตุที่ currentProblem จะเป็น -1 ตอนข้อสุดท้ายก็เพราะว่า ทุกครั้งที่กด ปุ่มใน modal เวลาเล่นข้อต่อไป มันจะ + currentProblem ตอน user 1 เล่นข้อสุดท้ายเสร็จก็จะ + ให้ current problem กลายเป็น 0 พอดี
<img width="294" alt="Screen Shot 2564-02-10 at 14 40 43" src="https://user-images.githubusercontent.com/42615865/107480236-da8bab00-6bae-11eb-9824-355dc9eb93eb.png">
