### PR TITLE
Fix/leader board logic

### DIFF
--- a/controllers/answer.js
+++ b/controllers/answer.js
@@ -22,8 +22,6 @@ const updateGroupScore = async (res, groupId, userId, correct, usedTime, correct
     if (usedTime >= +group.timePerProblem.toString() || !correct) {
     }
     else {
-      // group.members.find(member => member.userId.toString() === userId).score++; 
-      // group.members.find(member => member.userId.toString() === userId).point += calculatePoints(usedTime, group.timePerProblem, POINTS_POSSIBLE / group.problems.length);
       const user = group.members.find(member => member.userId.toString() === userId)
       user.score++;
       user.point += calculatePoints(usedTime, group.timePerProblem, POINTS_POSSIBLE / group.problems.length);

--- a/controllers/answer.js
+++ b/controllers/answer.js
@@ -22,8 +22,11 @@ const updateGroupScore = async (res, groupId, userId, correct, usedTime, correct
     if (usedTime >= +group.timePerProblem.toString() || !correct) {
     }
     else {
-      group.members.find(member => member.userId.toString() === userId).score++;
-      group.members.find(member => member.userId.toString() === userId).point += calculatePoints(usedTime, group.timePerProblem, POINTS_POSSIBLE / group.problems.length);
+      // group.members.find(member => member.userId.toString() === userId).score++; 
+      // group.members.find(member => member.userId.toString() === userId).point += calculatePoints(usedTime, group.timePerProblem, POINTS_POSSIBLE / group.problems.length);
+      const user = group.members.find(member => member.userId.toString() === userId)
+      user.score++;
+      user.point += calculatePoints(usedTime, group.timePerProblem, POINTS_POSSIBLE / group.problems.length);
     }
 
     if (group.members.some(e => e.userId == userId)) {


### PR DESCRIPTION
แก้ logic ตอน update score เวลาเล่น group ให้หา user รอบเดียวพอ ละ อัพเดท score กับ points ทีเดียวเลย ก่อนหน้านี้ ต้องเสิร์ชหา member 2 ครั้ง เพื่อจะอัพเดท score และ points